### PR TITLE
Ansible 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@ variables.json
 *.retry
 jdauphant.nginx
 vault.key
+# Vagrant & molecule
+.vagrant/
+.vagrant.d/
+*.log
+*.pyc
+.molecule
+.cache
+.pytest_cache
+__pycache__

--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -1,0 +1,38 @@
+Vagrant.configure("2") do |config|
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = 512
+    v.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+  end
+
+  config.vm.define "dbserver" do |db|
+    db.vm.box = "ubuntu/xenial64"
+    db.vm.hostname = "dbserver"
+    db.vm.network :private_network, ip: "10.10.10.10"
+  
+    db.vm.provision "ansible" do |ansible|
+      ansible.playbook = "playbooks/site.yml"
+      ansible.groups = {
+      "db" => ["dbserver"],
+      "db:vars" => {"mongo_bind_ip" => "0.0.0.0"}
+      }
+    end
+  end
+  
+  config.vm.define "appserver" do |app|
+    app.vm.box = "ubuntu/xenial64"
+    app.vm.hostname = "appserver"
+    app.vm.network :private_network, ip: "10.10.10.20"
+
+    app.vm.provision "ansible" do |ansible|
+      ansible.playbook = "playbooks/site.yml"
+      ansible.groups = {
+      "app" => ["appserver"],
+      "app:vars" => { "db_host" => "10.10.10.10"}
+      }
+      ansible.extra_vars = {
+        "deploy_user" => "vagrant"
+      }
+    end
+  end
+end

--- a/ansible/environments/stage/group_vars/app
+++ b/ansible/environments/stage/group_vars/app
@@ -1,7 +1,7 @@
-db_host: 10.132.15.204
+db_host: 10.132.15.210
 
 nginx_sites:
   default:
     - listen 80
     - server_name "reddit"
-    - location / { proxy_pass http://35.195.28.129:9292; }
+    - location / { proxy_pass http://34.76.117.19:9292; }

--- a/ansible/environments/stage/inventory
+++ b/ansible/environments/stage/inventory
@@ -1,5 +1,5 @@
 [app]
-appserver ansible_host=35.195.28.129
+appserver ansible_host=34.76.117.19
 
 [db]
-dbserver ansible_host=35.205.229.213
+dbserver ansible_host=35.195.28.129

--- a/ansible/playbooks/base.yml
+++ b/ansible/playbooks/base.yml
@@ -1,0 +1,10 @@
+---
+- name: Check && install python
+  hosts: all
+  become: true
+  gather_facts: False
+
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      changed_when: False

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -5,14 +5,14 @@
     - name: Fetch the latest version of application code
       git:
         repo: 'https://github.com/express42/reddit.git'
-        dest: /home/rustsh/reddit
+        dest: "/home/{{ deploy_user }}/reddit"
         version: monolith
       notify: restart puma
 
     - name: bundle install
       bundler:
         state: present
-        chdir: /home/rustsh/reddit
+        chdir: "/home/{{ deploy_user }}/reddit"
 
   handlers:
   - name: restart puma

--- a/ansible/playbooks/packer_app.yml
+++ b/ansible/playbooks/packer_app.yml
@@ -2,10 +2,5 @@
 - name: Install Ruby & Bundler
   hosts: all
   become: true
-  tasks:
-  - name: Install ruby, rubygems and required packages
-    apt: "name={{ item }} state=present"
-    with_items:
-      - ruby-full
-      - ruby-bundler
-      - build-essential
+  roles:
+    - app

--- a/ansible/playbooks/packer_db.yml
+++ b/ansible/playbooks/packer_db.yml
@@ -2,23 +2,5 @@
 - name: Install MongoDB
   hosts: all
   become: true
-  tasks:
-  - name: Add apt key
-    apt_key:
-      id: EA312927
-      keyserver: keyserver.ubuntu.com
-
-  - name: Add apt repository
-    apt_repository:
-      repo: deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse
-      state: present
-
-  - name: Install mongodb package
-    apt:
-      name: mongodb-org
-      state: present
-
-  - name: Configure service supervisor
-    systemd:
-      name: mongod
-      enabled: yes
+  roles:
+    - db

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,5 +1,5 @@
 ---
+- import_playbook: base.yml
 - import_playbook: db.yml
 - import_playbook: app.yml
 - import_playbook: deploy.yml
-- import_playbook: users.yml

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,1 +1,4 @@
 ansible>=2.4
+molecule>=2.6
+testinfra>=1.10
+python-vagrant>=0.5.15

--- a/ansible/roles/app/defaults/main.yml
+++ b/ansible/roles/app/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for app
 db_host: 127.0.0.1
 env: local
+deploy_user: rustsh

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -4,18 +4,5 @@
   debug:
     msg: "This host is in {{ env }} environment"
 
-- name: Add unit file for Puma
-  copy:
-    src: puma.service
-    dest: /etc/systemd/system/puma.service
-  notify: reload puma
-
-- name: Add config for DB connection
-  template:
-    src: db_config.j2
-    dest: /home/rustsh/db_config
-    owner: rustsh
-    group: rustsh
-
-- name: enable puma
-  systemd: name=puma enabled=yes
+- include: ruby.yml
+- include: puma.yml

--- a/ansible/roles/app/tasks/puma.yml
+++ b/ansible/roles/app/tasks/puma.yml
@@ -1,0 +1,16 @@
+---
+- name: Add unit file for Puma
+  template:
+    src: puma.service.j2
+    dest: /etc/systemd/system/puma.service
+  notify: reload puma
+
+- name: Add config for DB connection
+  template:
+    src: db_config.j2
+    dest: "/home/{{ deploy_user }}/db_config"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_user }}"
+
+- name: enable puma
+  systemd: name=puma enabled=yes

--- a/ansible/roles/app/tasks/ruby.yml
+++ b/ansible/roles/app/tasks/ruby.yml
@@ -1,0 +1,8 @@
+---
+- name: Install ruby and rubygems and required packages
+  apt: "name={{ item }} state=present"
+  with_items:
+    - ruby-full
+    - ruby-bundler
+    - build-essential
+  tags: ruby

--- a/ansible/roles/app/templates/puma.service.j2
+++ b/ansible/roles/app/templates/puma.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Puma HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/home/{{ deploy_user }}/db_config
+User={{ deploy_user }}
+WorkingDirectory=/home/{{ deploy_user }}/reddit
+ExecStart=/bin/bash -lc 'puma'
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/db/.yamllint
+++ b/ansible/roles/db/.yamllint
@@ -1,0 +1,11 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable

--- a/ansible/roles/db/molecule/default/INSTALL.rst
+++ b/ansible/roles/db/molecule/default/INSTALL.rst
@@ -1,0 +1,23 @@
+*******
+Vagrant driver installation guide
+*******
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[vagrant]'

--- a/ansible/roles/db/molecule/default/molecule.yml
+++ b/ansible/roles/db/molecule/default/molecule.yml
@@ -1,0 +1,22 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    box: ubuntu/xenial64
+    provider_raw_config_args:
+      - "customize [ 'modifyvm', :id, '--uartmode1', 'disconnected' ]"
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/ansible/roles/db/molecule/default/playbook.yml
+++ b/ansible/roles/db/molecule/default/playbook.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    mongo_bind_ip: 0.0.0.0
+  roles:
+    - role: db

--- a/ansible/roles/db/molecule/default/prepare.yml
+++ b/ansible/roles/db/molecule/default/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: true
+      changed_when: false

--- a/ansible/roles/db/molecule/default/tests/test_default.py
+++ b/ansible/roles/db/molecule/default/tests/test_default.py
@@ -1,0 +1,22 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+# check if MongoDB is enabled and running
+def test_mongo_running_and_enabled(host):
+    mongo = host.service("mongod")
+    assert mongo.is_running
+    assert mongo.is_enabled
+
+# check if configuration file contains the required line
+def test_config_file(host):
+    config_file = host.file('/etc/mongod.conf')
+    assert config_file.contains('bindIp: 0.0.0.0')
+    assert config_file.is_file
+
+# check if MongoDB listen port 27017
+def test_mongo_listen_port(host):
+    assert host.socket("tcp://0.0.0.0:27017").is_listening

--- a/ansible/roles/db/tasks/config_mongo.yml
+++ b/ansible/roles/db/tasks/config_mongo.yml
@@ -1,0 +1,7 @@
+---
+- name: Change mongo config file
+  template:
+    src: templates/mongod.conf.j2
+    dest: /etc/mongod.conf
+    mode: 0644
+  notify: restart mongod

--- a/ansible/roles/db/tasks/install_mongo.yml
+++ b/ansible/roles/db/tasks/install_mongo.yml
@@ -1,0 +1,24 @@
+- name: Add APT key
+  apt_key:
+    id: "EA312927"
+    keyserver: keyserver.ubuntu.com
+  tags: install
+
+- name: Add APT repository
+  apt_repository:
+    repo: deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse
+    state: present
+  tags: install
+
+- name: Install mongodb package
+  apt:
+    name: mongodb-org
+    state: present
+  tags: install
+
+- name: Configure service supervisor
+  systemd:
+    name: mongod
+    enabled: yes
+    state: started
+  tags: install

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -4,9 +4,5 @@
   debug:
     msg: "This host is in {{ env }} environment"
 
-- name: Change mongo config file
-  template:
-    src: mongod.conf.j2
-    dest: /etc/mongod.conf
-    mode: 0644
-  notify: restart mongod
+- include: install_mongo.yml
+- include: config_mongo.yml

--- a/packer/app.json
+++ b/packer/app.json
@@ -24,7 +24,14 @@
     "provisioners": [
         {
             "type": "ansible",
-            "playbook_file": "ansible/playbooks/packer_app.yml"
+            "playbook_file": "ansible/playbooks/packer_app.yml",
+            "extra_arguments": [
+                "--tags",
+                "ruby"
+            ],
+            "ansible_env_vars": [
+                "ANSIBLE_ROLES_PATH={{ pwd }}/ansible/roles"
+            ]
         }
     ]
 }

--- a/packer/db.json
+++ b/packer/db.json
@@ -24,7 +24,14 @@
     "provisioners": [
         {
             "type": "ansible",
-            "playbook_file": "ansible/playbooks/packer_db.yml"
+            "playbook_file": "ansible/playbooks/packer_db.yml",
+            "extra_arguments": [
+                "--tags",
+                "install"
+            ],
+            "ansible_env_vars": [
+                "ANSIBLE_ROLES_PATH={{ pwd }}/ansible/roles"
+            ]
 
         }
     ]


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ

## В процессе сделано:
1. В файле Vagrantfile описана локальная инфраструктура.
2. Настроена совместимость между Vagrant внутри WSL и VirtualBox в Windows:
    - в WSL и Windows установлена одинаковая версия Vagrant (2.0.2);
    - в Windows путь до VirtualBox добавлен в PATH;
    - в WSL заданы переменные окружения:
        ```bash
        $ export VAGRANT_WSL_ENABLE_WINDOWS_ACCESS="1"
        $ export PATH="$PATH:/mnt/c/Program Files/Oracle/VirtualBox"
        $ export VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH="/mnt/c/ansible"
        ```
    - в Vagrantfile в область настроек виртуальных машин добавлена строчка `v.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]` (без неё всё падает).
3. Командой `vagrant up` созданы виртуальные машины.
4. В Vagrantfile добавлен провижинер для dbserver.
5. Чтобы в WSL можно было настраивать права командой `chmod`, диск C: перемонтирован с метаданными:
    ```bash
    $ sudo umount /mnt/c
    $ sudo mount -t drvfs C: /mnt/c -o metadata
    ```
6. Чтобы Ansible выполнил плейбуки, настроены права для папки ansible и приватных ключей, созданных Vagrant'ом (выставлены более строгие).
7. В плейбуки добавлена установка Python, переработана роль db.
8. Аналогичные настройки сделаны для appserver.
9. Параметризировано имя пользователя на удалённой машине.
10. В WSL установлены Molecule и Testinfra.
11. Командой `molecule init` в роли db создана заготовка для тестов, в файл test_default.py добавлены сами тесты.
12. Чтобы Molecule из WSL заработал с VirtualBox в Windows, в файл molecule.yml в раздел platforms добавлен параметр provider_raw_config_args со значением `"customize [ 'modifyvm', :id, '--uartmode1', 'disconnected' ]"`.
13. Командой `molecule create` создана тестовая машина, к ней командой `molecule converge` применена роль db и командой `molecule verify` запущены тесты.
14. Добавлен тест для проверки того, что БД слушает порт 27017:
    ```python
    def test_mongo_listen_port(host):
        assert host.socket("tcp://0.0.0.0:27017").is_listening
    ```
15. В плейбуках packer_db.yml и packer_app.yml таски заменены на роли db и app, в шаблонах Packer'а app.json и db.json добавлена информация о тегах и пути до ролей.

## Как запустить проект:
 - Vagrant: выполнить команду `vagrant up`.
 - Molecule: последовательно выполнить команды `molecule init`, `molecule create`, `molecule converge` и `molecule verify` (или же выполнить одну команду `molecule test`).
 - Packer: удалить старые образы и выполнить команду `packer build`.

## Как проверить работоспособность:
 - Vagrant: перейти по ссылке 10.10.10.20:9292 и убедиться, что приложение reddit работает.
 - Molecule: дождаться сообщения об успешном прохождении тестов.
 - Packer: при помощи Terraform развернуть VM из новых образов, сконфигурировать их при помощи Ansible, открыть в браузере страницу по внешнему IP-адресу сервера приложений и убедиться, что приложение reddit работает.

## PR checklist
 - [x] Выставил label с темой домашнего задания